### PR TITLE
Add FactorioMaps integration

### DIFF
--- a/compat/factoriomaps.lua
+++ b/compat/factoriomaps.lua
@@ -1,0 +1,14 @@
+Compat = Compat or {}
+
+
+function Compat.handle_factoriomaps()
+	if remote.interfaces.factoriomaps then
+		script.on_event(remote.call("factoriomaps", "get_start_capture_event_id"), function() 
+
+			print("Starting factoriomaps-oarc integration script")
+		
+			remote.call("factoriomaps", "surface_set_default", "oarc")
+
+		end)
+	end
+end

--- a/control.lua
+++ b/control.lua
@@ -52,6 +52,9 @@ require("lib/separate_spawns_guis")
 
 require("lib/oarc_gui_tabs")
 
+-- compatibility with mods
+require("compat/factoriomaps")
+
 -- Create a new surface so we can modify map settings at the start.
 GAME_SURFACE_NAME="oarc"
 
@@ -99,6 +102,12 @@ script.on_init(function(event)
     global.vanillaSpawns = FYShuffle(global.vanillaSpawns)
     log("Vanilla spawns:")
     log(serpent.block(global.vanillaSpawns))
+
+    Compat.handle_factoriomaps()
+end)
+
+script.on_load(function()
+	Compat.handle_factoriomaps()
 end)
 
 


### PR DESCRIPTION
Lets factoriomaps know that everything is going on on oarc instead of on the default surface nauvis.

See L0laapk3/FactorioMaps#53.

Note that this will only work with FactorioMaps v3.5.4 or up, which I will release once any potential problems here are ironed out.