### PR TITLE
fix: put default values if map_setting's required values are nil

### DIFF
--- a/lib/holding_pen.lua
+++ b/lib/holding_pen.lua
@@ -18,6 +18,9 @@ function CreateHoldingPenSurface()
     map_settings.peaceful_mode = true
     map_settings.width = 64
     map_settings.height = 64
+    map_settings.autoplace_controls = {}
+    map_settings.autoplace_settings = {}
+    map_settings.default_enable_all_autoplace_controls = false
 
     -- Create a new surface for the holding pen
 

--- a/lib/holding_pen.lua
+++ b/lib/holding_pen.lua
@@ -18,9 +18,9 @@ function CreateHoldingPenSurface()
     map_settings.peaceful_mode = true
     map_settings.width = 64
     map_settings.height = 64
-    map_settings.autoplace_controls = {}
-    map_settings.autoplace_settings = {}
-    map_settings.default_enable_all_autoplace_controls = false
+    map_settings.autoplace_controls = map_settings.autoplace_controls or {}
+    map_settings.autoplace_settings = map_settings.autoplace_settings or {}
+    map_settings.default_enable_all_autoplace_controls = map_settings.default_enable_all_autoplace_controls or false
 
     -- Create a new surface for the holding pen
 


### PR DESCRIPTION
initial report: https://mods.factorio.com/mod/oarc-mod/discussion/681f6de96d7227df7b704b62

For some reason, there might be missing required values in `map_settings` to call `game.create_surface(...)`
For example, EverythingOnNauvis mod deletes prototype entirely for every planet, causing the error.

This PR fixes this error by providing default values in case the required values are nil
